### PR TITLE
Fix "cannot allocate color" error

### DIFF
--- a/plugin/vim-disapprove-deep-indentation.vim
+++ b/plugin/vim-disapprove-deep-indentation.vim
@@ -26,7 +26,7 @@ function! g:DisapproveDeepIndent()
     endif
 
     set conceallevel=1 concealcursor=nvic
-    hi conceal ctermfg=red ctermbg=none guifg=red guibg=none
+    hi conceal ctermfg=red ctermbg=NONE guifg=red guibg=NONE
 endfunction
 
 autocmd BufEnter,BufNewFile,BufReadPost * call DisapproveDeepIndent()


### PR DESCRIPTION
When I open vim, after installing, I get this error:
```
Error detected while processing function DisapproveDeepIndent:
line   23:
E254: Cannot allocate color none
Executing BufEnter Auto commands for "*"
autocommand call <SID>BufEnterHandler()
```
A complete log from running `vim -V9` can be found [here](https://gist.github.com/mattmahn/1081d00a41a840b2d7028b5390df8c19#file-indent_disapproval_error-log) with the [relevant section here](https://gist.github.com/mattmahn/1081d00a41a840b2d7028b5390df8c19#file-indent_disapproval_error-log-L3567-L3571).
[My vimrc](https://github.com/mattmahn/vimfiles/blob/e858114d7ff72aad34c4edb40ebfd320224f75a4/vimrc.symlink).

Changing `ctermbg` and `guibg` to `NONE` seems to fix this error.